### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,3 @@ Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.
 
 ## Running end-to-end tests
 Run `ng e2e` to execute the end-to-end tests via a platform of your choice. To use this command, you need to first add a package that implements end-to-end testing capabilities.
-
-## Further help
-To get more help on the Angular CLI use `ng help` or go check out the [Angular CLI Overview and Command Reference](https://angular.io/cli) page.

--- a/src/app/interfaces/ITeamMember.ts
+++ b/src/app/interfaces/ITeamMember.ts
@@ -1,9 +1,10 @@
 export interface ITeamMember {
     name: string
+    id: number
     guid: string
     img: string
     types: string[]
-    forms: string[]
+    forms: IForm[]
     abilities: string[]
     isAdvancedForm: boolean
     megaForms: string[]
@@ -39,4 +40,12 @@ export interface ITeamMember {
 export interface ITeam {
   hasAdvancedFrom: boolean,
   teamList: ITeamMember[]
+}
+
+export interface IForm {
+  is_default: boolean
+  pokemon: {
+    name: string
+    url: string
+  }
 }

--- a/src/app/team-builder/team-builder.component.html
+++ b/src/app/team-builder/team-builder.component.html
@@ -39,7 +39,7 @@
             <button hc-button class="dyna-btn" buttonStyle="secondary" buttonStyle="pink" [hcTooltip]="dynaTooltip" *ngIf="this.team.hasAdvancedFrom === false">
                 <img src="assets/dynamax.webp" height="30px" alt="Dynamax Icon">
             </button>
-            <button hc-button class="revert-btn" buttonStyle="secondary" [hcTooltip]="revertTooltip" *ngIf="pokemon.isAdvancedForm === true" (click)="updateMember(pokemon.guid, pokemon.forms[0])">
+            <button hc-button class="revert-btn" buttonStyle="secondary" [hcTooltip]="revertTooltip" *ngIf="pokemon.isAdvancedForm === true" (click)="updateMember(pokemon.guid, pokemon.forms[0].pokemon.name)">
                 <hc-icon hcMenuIcon fontSet="fa" fontIcon="fa-rotate-right"></hc-icon>
             </button>
             <div *ngIf="pokemon.gigantamaxForms.length > 0 && this.team.hasAdvancedFrom === false">
@@ -59,7 +59,7 @@
                     <option *ngFor="let nature of natures" value="{{pokemon.guid}}::{{nature.name}}::{{nature.stats.attack}}::{{nature.stats.defense}}::{{nature.stats.speed}}::{{nature.stats.spattack}}::{{nature.stats.spdefense}}">{{nature.name | titlecase}}</option>
                 </hc-select>
                 <hc-select placeholder="Form" *ngIf="pokemon.forms.length > 1" [formControl]="specialFormsControl" (change)="updateMember('00', 'useFormControl')">
-                    <option *ngFor="let form of pokemon.forms" value="{{pokemon.guid}}::{{form}}">{{form | removedash | titlecase}}</option>
+                    <option *ngFor="let form of pokemon.forms" value="{{pokemon.guid}}::{{form.pokemon.name}}">{{form.pokemon.name | removedash | titlecase}}</option>
                 </hc-select>
             </hc-form-field>
         </hc-accordion>

--- a/src/app/team-builder/team-builder.component.spec.ts
+++ b/src/app/team-builder/team-builder.component.spec.ts
@@ -34,6 +34,7 @@ describe('TeamBuilderComponent', () => {
   let testTeam: ITeamMember[] = [
     {
       name: "Mudkip",
+      id: 258,
       guid: "1",
       img: "https://www.serebii.net/swordshield/pokemon/258.png",
       types: [
@@ -44,6 +45,7 @@ describe('TeamBuilderComponent', () => {
         "torrent",
         "damp"
       ],
+      isAdvancedForm: false,
       megaForms: [],
       gigantamaxForms: [],
       baseStats: {
@@ -76,6 +78,7 @@ describe('TeamBuilderComponent', () => {
     {
       name: "Swampert",
       guid: "2",
+      id: 260,
       img: "https://www.serebii.net/swordshield/pokemon/260.png",
       types: [
         "water",
@@ -86,6 +89,7 @@ describe('TeamBuilderComponent', () => {
         "torrent",
         "damp"
       ],
+      isAdvancedForm: false,
       megaForms: ["swampert-mega"],
       gigantamaxForms: [],
       baseStats: {
@@ -118,6 +122,7 @@ describe('TeamBuilderComponent', () => {
     {
       name: "Charizard",
       guid: "3",
+      id: 6,
       img: "https://www.serebii.net/swordshield/pokemon/006.png",
       types: [
         "fire",
@@ -128,6 +133,7 @@ describe('TeamBuilderComponent', () => {
         "blaze",
         "solar-power"
       ],
+      isAdvancedForm: false,
       megaForms: ["charizard-mega-y","charizard-mega-y"],
       gigantamaxForms: ["charizard-gmax"],
       baseStats: {
@@ -159,6 +165,7 @@ describe('TeamBuilderComponent', () => {
     },
     {
       name: "pikachu",
+      id: 25,
       guid: "4",
       img: "https://www.serebii.net/swordshield/pokemon/025.png",
       types: [
@@ -170,6 +177,7 @@ describe('TeamBuilderComponent', () => {
         "lightning-rod",
         ""
       ],
+      isAdvancedForm: false,
       megaForms: [],
       gigantamaxForms: ["pikachu-gmax"],
       baseStats: {
@@ -201,6 +209,7 @@ describe('TeamBuilderComponent', () => {
     },
     {
       name: "Gengar",
+      id: 94,
       guid: "5",
       img: "https://www.serebii.net/swordshield/pokemon/094.png",
       types: [
@@ -211,6 +220,7 @@ describe('TeamBuilderComponent', () => {
       abilities: [
         "cursed-body"
       ],
+      isAdvancedForm: false,
       megaForms: ["gengar-mega"],
       gigantamaxForms: ["gengar-gmax"],
       baseStats: {
@@ -242,6 +252,7 @@ describe('TeamBuilderComponent', () => {
     },
     {
       name: "meowth",
+      id: 52,
       guid: "6",
       img: "https://www.serebii.net/swordshield/pokemon/052.png",
       types: [
@@ -256,6 +267,7 @@ describe('TeamBuilderComponent', () => {
         "technician",
         "unnerve"
       ],
+      isAdvancedForm: false,
       megaForms: [],
       gigantamaxForms: ["meowth-gmax"],
       baseStats: {

--- a/src/app/team-builder/team-builder.component.ts
+++ b/src/app/team-builder/team-builder.component.ts
@@ -88,8 +88,6 @@ export class TeamBuilderComponent implements OnInit {
     let value: string[] = [];
 
     form == "useFormControl" ? value = this.specialFormsControl.value.split("::") : value = [guid, form];
-
-    console.log(value)
     
     const updatedMember: ITeamMember = await this.pokeApiService.addMember(value[1], "updateMember", value[0]);
 


### PR DESCRIPTION
Updated Readme

Altered how PokeUtils gets a Pokemon's form data to use urls returned from PokeAPI instead of interpolated ones. This method appears safer.

Forms are no longer obtained by kind of guessing...PokeAPI has a varieties array that is now being used to build the forms data.